### PR TITLE
removing Scala.Js plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.8")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.16")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
 
 licenses += ("Three-clause BSD-style", url("https://github.com/scodec/scodec-build/blob/master/LICENSE"))
 

--- a/src/main/scala/scodec/build/ScodecBuildSettings.scala
+++ b/src/main/scala/scodec/build/ScodecBuildSettings.scala
@@ -24,9 +24,6 @@ import pl.project13.scala.sbt.SbtJmh
 import SbtJmh.autoImport._
 import sbtbuildinfo.BuildInfoPlugin
 import BuildInfoPlugin.autoImport._
-import org.scalajs.sbtplugin.ScalaJSPlugin
-import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
-import org.scalajs.jsenv.nodejs.NodeJSEnv
 
 object ScodecBuildSettings extends AutoPlugin {
 
@@ -49,9 +46,6 @@ object ScodecBuildSettings extends AutoPlugin {
     lazy val docSourcePath = settingKey[File]("Path to pass as -sourcepath argument to ScalaDoc")
 
     def commonJsSettings: Seq[Setting[_]] = Seq(
-      requiresDOM := false,
-      scalaJSStage in Test := FastOptStage,
-      jsEnv in Test := new NodeJSEnv(),
       scalacOptions in Compile += {
         val dir = project.base.toURI.toString.replaceFirst("[^/]+/?$", "")
         val url = s"https://raw.githubusercontent.com/scodec/${scodecModule.value}"


### PR DESCRIPTION
As already discussed I propose here to remove Scala.Js dependency to enable project define by themselves the version (i.e. this is necessary during migration from 0.6.X to 1.X.X)