### PR TITLE
"-Yno-adapted-args" removed since Scala 2.13.0-M4

### DIFF
--- a/src/main/scala/scodec/build/ScodecBuildSettings.scala
+++ b/src/main/scala/scodec/build/ScodecBuildSettings.scala
@@ -85,11 +85,12 @@ object ScodecBuildSettings extends AutoPlugin {
       "-feature",
       "-unchecked",
       "-Xlint",
-      "-Yno-adapted-args",
       "-Ywarn-dead-code",
       "-Ywarn-numeric-widen",
       "-Ywarn-value-discard",
       "-Xfuture"
+    ) ++ ifAtLeast("2.13", scalaVersion.value)(
+      "-Yno-adapted-args"
     ) ++ ifAtLeast(scalaBinaryVersion.value, "2.11.0")(
       "-Ywarn-unused-import"
     ),


### PR DESCRIPTION
https://github.com/scala/scala/commit/a82a56ea5ba1ff0fb3b69c0963d4aec620ab68ad